### PR TITLE
Refactor requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install -r requirements.txt
+  - pip install -r tests/requirements.txt
   - pip install -r $VIRTUAL_ENV/src/varda/requirements.txt
   - python setup.py install
 script: py.test

--- a/manwe/session.py
+++ b/manwe/session.py
@@ -9,7 +9,6 @@ Manwë sessions.
 
 
 import collections
-import functools
 import json
 import logging
 import requests
@@ -237,3 +236,16 @@ class Session(object):
     def _create_resource(self, key, *args, **kwargs):
         return self._collections[key].resource_class.create(self, *args,
                                                             **kwargs)
+
+
+# TODO: Some kind of session class factory would probably be better. It could
+# prepopulate all API call methods, which would also make them available to
+# Sphinx class documentation and the like.
+# Session = make_session_class(resources.AnnotationCollection,
+#                              resources.CoverageCollection,
+#                              resources.DataSourceCollection,
+#                              resources.GroupCollection,
+#                              resources.SampleCollection,
+#                              resources.UserCollection,
+#                              resources.VariantCollection,
+#                              resources.VariationCollection

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 if sys.version_info < (2, 7):
     raise Exception('Manwë requires Python 2.7 or higher.')
 
-install_requires = ['flask', 'python-dateutil', 'requests', 'Werkzeug']
+install_requires = ['python-dateutil', 'requests', 'Flask']
 
 try:
     with open('README.rst') as readme:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,3 @@
 httpretty==0.8.10
 pytest==2.7.2
-python-dateutil==1.5
-requests==1.1.0
-Flask==0.10.1
-Sphinx==1.1.3
-Werkzeug==0.8.3
 -e git+https://github.com/varda/varda.git@ee1e5bd#egg=varda


### PR DESCRIPTION
The unit test requirements are quite heavy (Varda), so we prefer to separate them from the main requirements.

Also, as this is a PyPI published package, we don't want to rely on specific versions of our dependencies, so we get rid of the main `requirements.txt` file (`setup.py` is enough).