### PR TITLE
Field definitions on resources

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -35,6 +35,14 @@ manwe.errors
    :show-inheritance:
 
 
+manwe.fields
+------------
+
+.. automodule:: manwe.fields
+   :members:
+   :show-inheritance:
+
+
 manwe.resources
 ---------------
 

--- a/manwe/fields.py
+++ b/manwe/fields.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+"""
+Manwë resource fields.
+
+.. moduleauthor:: Martijn Vermaat <martijn@vermaat.name>
+
+.. Licensed under the MIT license, see the LICENSE file.
+"""
+
+
+import dateutil.parser
+
+
+# This is in bytes. Should it be much higher?
+DATA_BUFFER_SIZE = 1024
+
+
+class Field(object):
+    """
+    Base class for resource field definitions.
+
+    A field definition can convert field values from their API representation
+    to their Python representation, and vice versa.
+    """
+    def __init__(self, key=None, mutable=False, hidden=False, default=None,
+                 doc=None):
+        """
+        Create a field instance.
+
+        :arg str key: Key by which this field is stored in the API.
+        :arg bool mutable: If `True`, field values can be modified.
+        :arg bool hidden: If `True`, field should not be shown.
+        :arg default: Default field value (as a Python value).
+        :arg str doc: Documentation string
+        """
+        #: Key by which this field is stored in the API. By default inherited
+        #: from :attr:`name`.
+        self.key = key
+
+        #: If `True`, field values can be modified.
+        self.mutable = mutable
+
+        #: If `True`, field should not be shown.
+        self.hidden = hidden
+
+        #: Default field value (as an API value).
+        self.default = self.from_python(default)
+
+        #: Documentation string.
+        self.doc = doc
+
+        self._name = None
+
+    @property
+    def name(self):
+        """
+        Name by which this field is available on the resource class.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+        if self.key is None:
+            self.key = self.name
+
+    def to_python(self, value, session=None):
+        """
+        Convert API value to Python value.
+
+        This gets called from field getters, so the user gets a nice Python
+        value when accessing the field.
+
+        Subclasses for structured data (such as lists and dicts) should be
+        careful to not return mutable structures here, since that would allow
+        to bypass the field setter. For example, calling `field.append(v)`
+        will not add `field` to the set of dirty fields and will not go
+        through :meth:`from_python`. Actually, it might not even modify the
+        API value on the resource, because :meth:`to_python` probably created
+        a copy.
+
+        One solution for this, as implemented on :class:`Set`, is to return an
+        immutable field value (a `frozenset` in this case) and thereby force
+        modifications through the field setter.
+
+        Another approach would be something similar to the `MutableDict` type
+        in SQLAlchemy (see `Mutation Tracking
+        <http://docs.sqlalchemy.org/en/latest/orm/extensions/mutable.html>`_).
+
+        This does not apply to :class:`Link` fields, where the value is itself
+        a resource which should be modified using its own
+        :meth:`resources.Resource.save` method.
+        """
+        return value
+
+    def from_python(self, value):
+        """
+        Convert Python value to API value.
+        """
+        return value
+
+
+class Boolean(Field):
+    pass
+
+
+class Integer(Field):
+    pass
+
+
+class String(Field):
+    pass
+
+
+class Link(Field):
+    """
+    Definition for a resource link.
+    """
+    def __init__(self, resource_key, *args, **kwargs):
+        """
+        :arg str resource_key: Key for the linked resource.
+        """
+        self.resource_key = resource_key
+        super(Link, self).__init__(*args, **kwargs)
+
+    def to_python(self, value, session):
+        """
+        Create a :class:`resources.Resource` instance from the resource URI.
+
+        Modifications of the returned resource should be saved by calling
+        :meth:`resources.Resource.save` on that resource.
+        """
+        if value is None:
+            return None
+        # This is a bit ugly. In request data, a resource link is represented
+        # by its uri (a string). But in response data, it is represented by an
+        # object with a uri key.
+        if isinstance(value, dict):
+            uri = value['uri']
+        else:
+            uri = value
+        return getattr(session, self.resource_key)(uri)
+
+    def from_python(self, value):
+        """
+        In request data, a resource link is represented by its URI (a string).
+        """
+        if value is None:
+            return None
+        return value.uri
+
+
+class DateTime(Field):
+    def to_python(self, value, session=None):
+        if value is None:
+            return None
+        return dateutil.parser.parse(value)
+
+    def from_python(self, value):
+        if value is None:
+            return None
+        return value.isoformat()
+
+
+class Blob(Field):
+    def to_python(self, value, session):
+        """
+        Iterator over the data source data by chunks.
+        """
+        if value is None:
+            return None
+        return session.get(value['uri'], stream=True).iter_content(
+            chunk_size=DATA_BUFFER_SIZE)
+
+    def from_python(self, value):
+        if value is None:
+            return None
+        raise NotImplementedError()
+
+
+class Set(Field):
+    def __init__(self, field, *args, **kwargs):
+        """
+        :arg field: Field definition for the set members.
+        :type field: :class:`Field`
+        """
+        self.field = field
+        super(Set, self).__init__(*args, **kwargs)
+
+    def to_python(self, value, session=None):
+        """
+        Convert the set to an immutable `fronzenset`. See the
+        :meth:`Field.to_python` docstring.
+        """
+        if value is None:
+            return None
+        return frozenset(self.field.to_python(x, session) for x in value)
+
+    def from_python(self, value):
+        if value is None:
+            return None
+        return [self.field.from_python(x) for x in value]
+
+
+class Task(Field):
+    # TODO: Do something more intelligent.
+    pass
+
+
+class Queries(Field):
+    """
+    Definition for a field containing annotation queries.
+
+    In the API, annotation queries are lists of dictionaries with `name` and
+    `expression` items.
+
+    As a Python value, we represent this as a dictionary with keys the query
+    names and values the query expressions.
+    """
+    def to_python(self, value, session=None):
+        if value is None:
+            return None
+        return {q['name']: q['expression'] for q in value}
+
+    def from_python(self, value):
+        if value is None:
+            return None
+        return [{'name': k, 'expression': v} for k, v in value.items()]

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -19,11 +19,11 @@ class TestAnnotation(object):
         """
         Read field values from an annotation with correct types.
         """
-        fields = dict(uri='/annotations/3',
+        values = dict(uri='/annotations/3',
                       original_data_source={'uri': '/data_sources/4'},
                       annotated_data_source={'uri': '/data_sources/6'})
 
-        annotation = resources.Annotation(None, fields)
+        annotation = resources.Annotation(None, values)
         assert annotation.uri == '/annotations/3'
 
 
@@ -32,11 +32,11 @@ class TestCoverage(object):
         """
         Read field values from a coverage with correct types.
         """
-        fields = dict(uri='/coverages/8',
+        values = dict(uri='/coverages/8',
                       sample={'uri': '/samples/3'},
                       data_source={'uri': '/data_sources/1'})
 
-        coverage = resources.Coverage(None, fields)
+        coverage = resources.Coverage(None, values)
         assert coverage.uri == '/coverages/8'
 
 
@@ -45,7 +45,7 @@ class TestDataSource(object):
         """
         Read field values from a data source with correct types.
         """
-        fields = dict(uri='/data_sources/4',
+        values = dict(uri='/data_sources/4',
                       name='test',
                       user={'uri': '/users/2'},
                       data={'uri': '/data_sources/4/data'},
@@ -53,7 +53,7 @@ class TestDataSource(object):
                       gzipped=True,
                       added='2012-11-23T10:55:12')
 
-        data_source = resources.DataSource(None, fields)
+        data_source = resources.DataSource(None, values)
         assert data_source.uri == '/data_sources/4'
         assert data_source.gzipped
         assert data_source.added == datetime.datetime(2012, 11, 23, 10, 55, 12)
@@ -64,7 +64,7 @@ class TestSample(object):
         """
         Read field values from a sample with correct types.
         """
-        fields =  {'name': 'test sample',
+        values =  {'name': 'test sample',
                    'pool_size': 5,
                    'coverage_profile': True,
                    'public': False,
@@ -73,7 +73,7 @@ class TestSample(object):
                    'active': True,
                    'notes': 'Some test notes',
                    'added': '2012-11-23T10:55:12'}
-        sample = resources.Sample(None, fields)
+        sample = resources.Sample(None, values)
         assert sample.name == 'test sample'
         assert sample.pool_size == 5
         assert not sample.public
@@ -90,7 +90,7 @@ class TestSample(object):
                 return 'mock user'
         s = MockSession()
 
-        fields =  {'name': 'test sample',
+        values =  {'name': 'test sample',
                    'pool_size': 5,
                    'coverage_profile': True,
                    'public': False,
@@ -98,7 +98,7 @@ class TestSample(object):
                    'user': {'uri': '/users/8'},
                    'active': True,
                    'added': '2012-11-23T10:55:12'}
-        sample = resources.Sample(s, fields)
+        sample = resources.Sample(s, values)
         user = sample.user
         assert user == 'mock user'
 
@@ -106,7 +106,7 @@ class TestSample(object):
         """
         Edit field values of a sample.
         """
-        fields =  {'name': 'test sample',
+        values =  {'name': 'test sample',
                    'pool_size': 5,
                    'coverage_profile': True,
                    'public': False,
@@ -114,16 +114,17 @@ class TestSample(object):
                    'user': {'uri': '/users/8'},
                    'active': True,
                    'added': '2012-11-23T10:55:12'}
-        sample = resources.Sample(None, fields)
+        sample = resources.Sample(None, values)
         assert not sample.dirty
         sample.name = 'edited test sample'
+        assert sample.name == 'edited test sample'
         assert sample.dirty
 
     def test_edit_immutable_sample(self):
         """
         Edit immutable field values of a sample.
         """
-        fields =  {'name': 'test sample',
+        values =  {'name': 'test sample',
                    'pool_size': 5,
                    'coverage_profile': True,
                    'public': False,
@@ -131,7 +132,7 @@ class TestSample(object):
                    'user': {'uri': '/users/8'},
                    'active': True,
                    'added': '2012-11-23T10:55:12'}
-        sample = resources.Sample(None, fields)
+        sample = resources.Sample(None, values)
         with pytest.raises(AttributeError):
             sample.uri = '/some/uri/88'
 
@@ -184,14 +185,14 @@ class TestUser(object):
         """
         Read field values from a user with correct types.
         """
-        fields = dict(uri='/users/4',
+        values = dict(uri='/users/4',
                       name='test',
                       login='test',
                       email='test@test.com',
                       roles=['importer'],
                       added='2012-11-23T10:55:12')
 
-        user = resources.User(None, fields)
+        user = resources.User(None, values)
         assert user.uri == '/users/4'
         assert user.email == 'test@test.com'
         assert user.roles == {'importer'}
@@ -201,28 +202,29 @@ class TestUser(object):
         """
         Edit field values of a user.
         """
-        fields = dict(uri='/users/4',
+        values = dict(uri='/users/4',
                       name='test',
                       login='test',
                       roles=['importer'],
                       added='2012-11-23T10:55:12')
 
-        user = resources.User(None, fields)
+        user = resources.User(None, values)
         assert not user.dirty
         user.name = 'edited test user'
+        assert user.name == 'edited test user'
         assert user.dirty
 
     def test_add_user_role_directly(self):
         """
         Try to add role to a user directly.
         """
-        fields = dict(uri='/users/4',
+        values = dict(uri='/users/4',
                       name='test',
                       login='test',
                       roles=['importer'],
                       added='2012-11-23T10:55:12')
 
-        user = resources.User(None, fields)
+        user = resources.User(None, values)
         with pytest.raises(AttributeError):
             user.roles.add('annotator')
 
@@ -230,59 +232,59 @@ class TestUser(object):
         """
         Add role to a user.
         """
-        fields = dict(uri='/users/4',
+        values = dict(uri='/users/4',
                       name='test',
                       login='test',
                       roles=['importer'],
                       added='2012-11-23T10:55:12')
 
-        user = resources.User(None, fields)
+        user = resources.User(None, values)
         assert not user.dirty
-        user.add_role('annotator')
-        assert user.dirty
+        user.roles = list(user.roles) + ['annotator']
         assert user.roles == {'importer', 'annotator'}
+        assert user.dirty
 
     def test_remove_user_role(self):
         """
         Remove role from a user.
         """
-        fields = dict(uri='/users/4',
+        values = dict(uri='/users/4',
                       name='test',
                       login='test',
                       roles=['importer'],
                       added='2012-11-23T10:55:12')
 
-        user = resources.User(None, fields)
+        user = resources.User(None, values)
         assert not user.dirty
-        user.remove_role('importer')
-        assert user.dirty
+        user.roles = [r for r in user.roles if r != 'importer']
         assert user.roles == set()
+        assert user.dirty
 
     def test_edit_user_role(self):
         """
         Edit roles field values of a user.
         """
-        fields = dict(uri='/users/4',
+        values = dict(uri='/users/4',
                       name='test',
                       login='test',
                       roles=['importer'],
                       added='2012-11-23T10:55:12')
 
-        user = resources.User(None, fields)
+        user = resources.User(None, values)
         assert not user.dirty
-        user.roles = {'importer', 'annotator'}
-        assert user.dirty
+        user.roles = ['importer', 'annotator']
         assert user.roles == {'importer', 'annotator'}
+        assert user.dirty
 
     def test_user_eq(self):
         """
         Compare two equal users.
         """
-        fields_a = dict(uri='/users/4', login='test')
-        fields_b = dict(uri='/users/4', login='test')
+        values_a = dict(uri='/users/4', login='test')
+        values_b = dict(uri='/users/4', login='test')
 
-        user_a = resources.User(None, fields_a)
-        user_b = resources.User(None, fields_b)
+        user_a = resources.User(None, values_a)
+        user_b = resources.User(None, values_b)
 
         assert user_a == user_b
 
@@ -290,11 +292,11 @@ class TestUser(object):
         """
         Compare two users with equal URIs.
         """
-        fields_a = dict(uri='/users/4', login='test a')
-        fields_b = dict(uri='/users/4', login='test b')
+        values_a = dict(uri='/users/4', login='test a')
+        values_b = dict(uri='/users/4', login='test b')
 
-        user_a = resources.User(None, fields_a)
-        user_b = resources.User(None, fields_b)
+        user_a = resources.User(None, values_a)
+        user_b = resources.User(None, values_b)
 
         assert user_a == user_b
 
@@ -302,11 +304,11 @@ class TestUser(object):
         """
         Compare two inequal users.
         """
-        fields_a = dict(uri='/users/4', login='test a')
-        fields_b = dict(uri='/users/6', login='test b')
+        values_a = dict(uri='/users/4', login='test a')
+        values_b = dict(uri='/users/6', login='test b')
 
-        user_a = resources.User(None, fields_a)
-        user_b = resources.User(None, fields_b)
+        user_a = resources.User(None, values_a)
+        user_b = resources.User(None, values_b)
 
         assert user_a != user_b
 
@@ -314,11 +316,11 @@ class TestUser(object):
         """
         Compare two users with inequal URIs.
         """
-        fields_a = dict(uri='/users/4', login='test a')
-        fields_b = dict(uri='/users/6', login='test a')
+        values_a = dict(uri='/users/4', login='test a')
+        values_b = dict(uri='/users/6', login='test a')
 
-        user_a = resources.User(None, fields_a)
-        user_b = resources.User(None, fields_b)
+        user_a = resources.User(None, values_a)
+        user_b = resources.User(None, values_b)
 
         assert user_a != user_b
 
@@ -328,13 +330,13 @@ class TestVariant(object):
         """
         Read field values from a variant with correct types.
         """
-        fields = dict(uri='/variants/3',
+        values = dict(uri='/variants/3',
                       chromosome='chr5',
                       position=45353,
                       reference='AT',
                       observed='TA')
 
-        variant = resources.Variant(None, fields)
+        variant = resources.Variant(None, values)
         assert variant.uri == '/variants/3'
         assert variant.chromosome == 'chr5'
         assert variant.position == 45353
@@ -347,9 +349,9 @@ class TestVariation(object):
         """
         Read field values from a variation with correct types.
         """
-        fields = dict(uri='/variations/23',
+        values = dict(uri='/variations/23',
                       sample={'uri': '/samples/3'},
                       data_source={'uri': '/data_sources/6'})
 
-        variation = resources.Variation(None, fields)
+        variation = resources.Variation(None, values)
         assert variation.uri == '/variations/23'

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ Unit tests for :mod:`manwe.session`.
 
 import os
 import gzip
+import shutil
 import zlib
 
 import pytest
@@ -40,6 +41,24 @@ class TestSession(utils.TestEnvironment):
 
         data_source_uri = self.uri_for_data_source(name='test data source')
         assert data_source.uri == data_source_uri
+
+    def test_create_annotation(self):
+        """
+        Create an annotation.
+        """
+        admin = varda.models.User.query.filter_by(name='Administrator').one()
+        varda.db.session.add(varda.models.DataSource(
+            admin, 'test data source', 'vcf', local_file='test.vcf.gz',
+            gzipped=True))
+        varda.db.session.commit()
+
+        data_source_uri = self.uri_for_data_source(name='test data source')
+        data_source = self.session.data_source(data_source_uri)
+
+        annotation = self.session.create_annotation(data_source, name='test annotation')
+
+        annotation_uri = self.uri_for_annotation()
+        assert annotation.uri == annotation_uri
 
     def test_samples_by_public(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ Utilities for Manwë unit tests.
 """
 
 
+import os
 import re
 import shutil
 import tempfile
@@ -28,6 +29,7 @@ class TestEnvironment(object):
         self._varda = varda.create_app({
             'TESTING': True,
             'DATA_DIR': self._temp_dir,
+            'SECONDARY_DATA_DIR': os.path.dirname(os.path.realpath(__file__)),
             'GENOME': None,
             'REFERENCE_MISMATCH_ABORT': False,
             'SQLALCHEMY_DATABASE_URI': 'sqlite://',
@@ -105,6 +107,13 @@ class TestEnvironment(object):
     def _uri_for(self, model, resource, **criteria):
         instance = model.query.filter_by(**criteria).first()
         return self._uri_for_instance(resource, instance)
+
+    def uri_for_annotation(self, **criteria):
+        """
+        Get API URI for an annotation.
+        """
+        return self._uri_for(varda.models.Annotation,
+                             varda.api.views.annotations_resource, **criteria)
 
     def uri_for_data_source(self, **criteria):
         """


### PR DESCRIPTION
Using a metaclass approach similar to what Django uses for its
model fields, we now define fields on resource classes with field
classes.

This allows for more flexibility in field types and conversions
of their values from the API to Python and vice versa. It also
makes for better Sphinx generated API docs and discoverability
of the Python API (tab completion and docstrings).